### PR TITLE
Make setup a separate notebook

### DIFF
--- a/00 Setup.ipynb
+++ b/00 Setup.ipynb
@@ -2,33 +2,12 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "source": [
-    "Welcome to a short course which will introduce you to some techniques and processes which are essential if you are going to be developing professional-quality software.\n",
-    "\n",
-    "For this course we will be focusing on three main topics:\n",
-    "1. documentation\n",
-    "2. licensing\n",
-    "3. testing\n",
-    "\n",
-    "and discussing why they're important and how to integrate them into your code. You can jump ahead to any chapter:"
-   ],
-   "metadata": {}
-  },
-  {
-   "cell_type": "markdown",
-   "source": [],
    "metadata": {
-    "tags": [
-     "toc"
-    ]
-   }
-  },
-  {
-   "cell_type": "markdown",
+    "hideCode": false,
+    "hidePrompt": false
+   },
    "source": [
-    "To discover these concepts we will be exploring then in Python but the ideas behind what we're doing here apply to all programming languages. You can do documentation and testing in C, C++, R, Fortran, Julia, Go and Rust but each will have their own tools and techniques. Languages which make going these things easy are good languages for doing software development in.\n",
-    "\n",
-    "## Setup\n",
+    "# Setup\n",
     "\n",
     "For the purpose of this course we will be using a free tool called JupyterLab which provides you with a local editor in your web browser where you can write and run Python code. The easiest way to get access to JupyterLab is to [install the Anaconda Distribution](https://www.anaconda.com/distribution/) which is a piece of software which includes Python along with lots of other tools. It is available for Windows, MacOS and Linux.\n",
     "\n",
@@ -40,7 +19,7 @@
     "\n",
     "![JupyterLab](jupyterlab1.png \"JupyterLab\")\n",
     "\n",
-    "## Screen layout\n",
+    "# Screen layout\n",
     "\n",
     "The way that we will be setting up the space is to have a text editor on the left-hand side of the screen and a terminal on the right hand side. We'll use the editor to write our code and the terminal to run it.\n",
     "\n",
@@ -67,8 +46,9 @@
  ],
  "metadata": {
   "celltoolbar": "Tags",
+  "hide_code_all_hidden": false,
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -82,7 +62,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,

--- a/00_introduction.md
+++ b/00_introduction.md
@@ -1,7 +1,5 @@
 # Introduction
 
-[Introduction notebook](notebooks/index.html)
-
 Welcome to a short course which will introduce you to some techniques and processes which are essential if you are going to be developing professional-quality software.
 
 For this course we will be focusing on three main topics:
@@ -12,3 +10,13 @@ For this course we will be focusing on three main topics:
 and discussing why they're important and how to integrate them into your code.
 
 To discover these concepts we will be exploring then in Python but the ideas behind what we're doing here apply to all programming languages. You can do documentation and testing in C, C++, R, Fortran, Julia, Go and Rust but each will have their own tools and techniques. Languages which make going these things easy are good languages for doing software development in.
+
+# Contents
+
+* [Setup](notebooks/index.html)
+* [Documentation](notebooks/Documentation.html)
+* [Licensing](notebooks/Licensing.html)
+* [Testing](notebooks/Testing.html)
+* [Fixtures](notebooks/Fixtures.html)
+* [Exercise](notebooks/Exercise.html)
+* [Summary](notebooks/Summary.html)

--- a/00_introduction.md
+++ b/00_introduction.md
@@ -1,0 +1,14 @@
+# Introduction
+
+[Introduction notebook](notebooks/index.html)
+
+Welcome to a short course which will introduce you to some techniques and processes which are essential if you are going to be developing professional-quality software.
+
+For this course we will be focusing on three main topics:
+1. documentation
+2. licensing
+3. testing
+
+and discussing why they're important and how to integrate them into your code.
+
+To discover these concepts we will be exploring then in Python but the ideas behind what we're doing here apply to all programming languages. You can do documentation and testing in C, C++, R, Fortran, Julia, Go and Rust but each will have their own tools and techniques. Languages which make going these things easy are good languages for doing software development in.


### PR DESCRIPTION
Introduction and setup instructions were part of the same document. Setup is now independent and introduction material is in slides, along with links to other notebooks. This can only be properly tested on merge.